### PR TITLE
Expose search RDD API as public trait

### DIFF
--- a/.github/workflows/workflow-ci.yaml
+++ b/.github/workflows/workflow-ci.yaml
@@ -70,8 +70,8 @@ jobs:
           timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' localhost 8082
           timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' localhost 8083
           docker cp examples/target/spark-search-examples_*.jar spark-master:/spark-search-examples.jar
-          docker exec spark-master /spark/bin/spark-submit --master spark://spark-master:7077 --deploy-mode client --class org.apache.spark.search.rdd.SearchRDDExamples /spark-search-examples.jar
-          #docker exec spark-master /spark/bin/spark-submit --master spark://spark-master:7077 --deploy-mode client --class org.apache.spark.search.rdd.SearchRDDJavaExamples /spark-search-examples.jar
+          docker exec spark-master /spark/bin/spark-submit --master spark://spark-master:7077 --deploy-mode client --class all.examples.org.apache.spark.search.rdd.SearchRDDExamples /spark-search-examples.jar
+          #docker exec spark-master /spark/bin/spark-submit --master spark://spark-master:7077 --deploy-mode client --class all.examples.org.apache.spark.search.rdd.SearchRDDJavaExamples /spark-search-examples.jar
 
   run-examples-yarn:
     needs: build-and-test
@@ -101,6 +101,6 @@ jobs:
         run: |
           timeout 30 sh -c 'until nc -z $0 $1; do sleep 1; done' localhost 50070
           docker cp examples/target/spark-search-examples_*.jar node-master:/spark-search-examples.jar
-          docker exec node-master /opt/spark/bin/spark-submit --master yarn --deploy-mode client --conf spark.hadoop.yarn.timeline-service.enabled=false --class org.apache.spark.search.rdd.SearchRDDExamples /spark-search-examples.jar
-          #docker exec node-master /opt/spark/bin/spark-submit --master yarn --deploy-mode client --conf spark.hadoop.yarn.timeline-service.enabled=false --class org.apache.spark.search.rdd.SearchRDDJavaExamples /spark-search-examples.jar
+          docker exec node-master /opt/spark/bin/spark-submit --master yarn --deploy-mode client --conf spark.hadoop.yarn.timeline-service.enabled=false --class all.examples.org.apache.spark.search.rdd.SearchRDDExamples /spark-search-examples.jar
+          #docker exec node-master /opt/spark/bin/spark-submit --master yarn --deploy-mode client --conf spark.hadoop.yarn.timeline-service.enabled=false --class all.examples.org.apache.spark.search.rdd.SearchRDDJavaExamples /spark-search-examples.jar
 

--- a/.github/workflows/workflow-ci.yaml
+++ b/.github/workflows/workflow-ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         scala: [ '2.11', '2.12' ]
-        spark: [ '2.4.5', '3.0.0' ]
+        spark: [ '2.4.8', '3.0.0' ]
         include:
           - scala: '2.11'
             spark: '3.0.0'

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ val restoredSearchRDD = SearchRDD.load[Review](sc, "hdfs:///path-for-later-query
 restoredSearchRDD.searchDropDuplicates()
 ```
 
-See [Examples](examples/src/main/scala/org/apache/spark/search/rdd/SearchRDDExamples.scala) for more details.
+See [Examples](examples/src/main/scala/all/examples/org/apache/spark/search/rdd/SearchRDDExamples.scala) for more details.
 
 * Java
 ```java
@@ -105,7 +105,7 @@ searchRDDJava.searchList("reviewerName:Patrik", 100)
         .map(Review::getReviewerName)
         .forEach(System.out::println);
 ```
-See [Examples](examples/src/main/java/org/apache/spark/search/rdd/SearchRDDJavaExamples.java) for more details.
+See [Examples](examples/src/main/java/all/examples/org/apache/spark/search/rdd/SearchRDDJavaExamples.java) for more details.
 
 ## Benchmark
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ matchesReviewersRDD
 
 // Save then restore onto hdfs
 matchesReviewersRDD.save("hdfs:///path-for-later-query-on")
-val restoredSearchRDD = SearchRDD.load[Review](sc, "hdfs:///path-for-later-query-on")
+val restoredSearchRDD = loadSearchRDD[Review](sc, "hdfs:///path-for-later-query-on")
 
 // Drop duplicates (see options)
 restoredSearchRDD.searchDropDuplicates()

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The general use cases is to match company names against two data sets (7M vs 600
 
 * Enable caching of search index rdd only for yarn cluster, and as an option.
 * Remove scala binary version in parent module artifact name
+* Expose SearchRDD as a public API to ease Dataset binding and hdfs reloading
 
 ##### v0.1.6
 * Switch to multi modules build: core, sql, examples, benchmark

--- a/benchmark/src/main/scala/benchmark/SearchRDDBenchmark.scala
+++ b/benchmark/src/main/scala/benchmark/SearchRDDBenchmark.scala
@@ -39,7 +39,7 @@ object SearchRDDBenchmark extends BaseBenchmark("SearchRDD") {
       .analyzer(classOf[StandardAnalyzer]).build
 
     companies.searchRDD(opts)
-      .searchQueryJoin(secEdgarCompanies,
+      .searchJoinQuery(secEdgarCompanies,
         queryBuilder[SecEdgarCompanyInfo]((c: SecEdgarCompanyInfo, lqb: QueryBuilder) =>
           lqb.createPhraseQuery("name", c.companyName.slice(0, 64)), opts), 1, 0d)
       .filter(_.hits.nonEmpty).map(m => (m.doc.companyName, m.hits.head.score, m.hits.head.source.name))

--- a/core/src/main/java/org/apache/spark/search/rdd/ISearchRDDJava.java
+++ b/core/src/main/java/org/apache/spark/search/rdd/ISearchRDDJava.java
@@ -31,22 +31,22 @@ public interface ISearchRDDJava<T> {
     long count();
 
     /**
-     * {@link org.apache.spark.search.rdd.SearchRDD#count(org.apache.lucene.search.Query)}
+     * {@link org.apache.spark.search.rdd.SearchRDD#count(String)}
      */
     long count(String query);
 
     /**
-     * {@link org.apache.spark.search.rdd.SearchRDD#searchListQuery(org.apache.lucene.search.Query, int, double)}
+     * {@link org.apache.spark.search.rdd.SearchRDD#searchList(String, int, double)}
      */
     SearchRecordJava<T>[] searchList(String query, int topK);
 
     /**
-     * {@link org.apache.spark.search.rdd.SearchRDD#searchListQuery(org.apache.lucene.search.Query, int, double)}
+     * {@link org.apache.spark.search.rdd.SearchRDD#searchList(String, int, double)}
      */
     SearchRecordJava<T>[] searchList(String query, int topK, double minScore);
 
     /**
-     * {@link org.apache.spark.search.rdd.SearchRDD#searchQuery(org.apache.lucene.search.Query, int, double)}
+     * {@link org.apache.spark.search.rdd.SearchRDD#search(String, int, double)}
      */
     JavaRDD<SearchRecordJava<T>> search(String query, int topK, double minScore);
 

--- a/core/src/main/java/org/apache/spark/search/rdd/ISearchRDDJava.java
+++ b/core/src/main/java/org/apache/spark/search/rdd/ISearchRDDJava.java
@@ -36,17 +36,17 @@ public interface ISearchRDDJava<T> {
     long count(String query);
 
     /**
-     * {@link org.apache.spark.search.rdd.SearchRDD#searchList(org.apache.lucene.search.Query, int, double)}
+     * {@link org.apache.spark.search.rdd.SearchRDD#searchListQuery(org.apache.lucene.search.Query, int, double)}
      */
     SearchRecordJava<T>[] searchList(String query, int topK);
 
     /**
-     * {@link org.apache.spark.search.rdd.SearchRDD#searchList(org.apache.lucene.search.Query, int, double)}
+     * {@link org.apache.spark.search.rdd.SearchRDD#searchListQuery(org.apache.lucene.search.Query, int, double)}
      */
     SearchRecordJava<T>[] searchList(String query, int topK, double minScore);
 
     /**
-     * {@link org.apache.spark.search.rdd.SearchRDD#search(org.apache.lucene.search.Query, int, double)}
+     * {@link org.apache.spark.search.rdd.SearchRDD#searchQuery(org.apache.lucene.search.Query, int, double)}
      */
     JavaRDD<SearchRecordJava<T>> search(String query, int topK, double minScore);
 

--- a/core/src/main/java/org/apache/spark/search/rdd/SearchRDDJava.java
+++ b/core/src/main/java/org/apache/spark/search/rdd/SearchRDDJava.java
@@ -21,7 +21,7 @@ import org.apache.spark.search.SearchRecordJava;
 import scala.reflect.ClassTag;
 
 /**
- * Java friendly version of {@link SearchRDD}.
+ * Java friendly version of {@link SearchRDDLucene}.
  */
 public class SearchRDDJava<T> extends JavaRDD<T> implements ISearchRDDJava<T> {
     private static final long serialVersionUID = 1L;

--- a/core/src/main/java/org/apache/spark/search/rdd/SearchRDDJava.java
+++ b/core/src/main/java/org/apache/spark/search/rdd/SearchRDDJava.java
@@ -21,7 +21,7 @@ import org.apache.spark.search.SearchRecordJava;
 import scala.reflect.ClassTag;
 
 /**
- * Java friendly version of {@link SearchRDDLucene}.
+ * Java friendly version of {@link SearchRDD}.
  */
 public class SearchRDDJava<T> extends JavaRDD<T> implements ISearchRDDJava<T> {
     private static final long serialVersionUID = 1L;

--- a/core/src/main/scala/org/apache/spark/search/package.scala
+++ b/core/src/main/scala/org/apache/spark/search/package.scala
@@ -100,9 +100,9 @@ package object search {
   def queryStringBuilder[T](builder: T => String, opts: SearchOptions[_] = defaultOpts): T => Query =
     new QueryStringBuilderWithAnalyzer[T](builder, opts.getReaderOptions.getDefaultFieldName)
 
-  def parseQueryString[T](queryString: String, opts: SearchOptions[_] = defaultOpts): () => Query =
+  def parseQueryString[T](queryString: String, opts: SearchOptions[_] = defaultOpts): Query =
   // Query parser is not thread safe
-    () => new QueryParser(opts.getReaderOptions.getDefaultFieldName, opts.getReaderOptions.analyzer.newInstance())
+    new QueryParser(opts.getReaderOptions.getDefaultFieldName, opts.getReaderOptions.analyzer.newInstance())
       .parse(queryString)
 
   implicit def indexOptions[T](optionsBuilderFunc: Function[IndexationOptions.Builder[T], IndexationOptions.Builder[T]]): JFunction[IndexationOptions.Builder[T], IndexationOptions.Builder[T]] =

--- a/core/src/main/scala/org/apache/spark/search/package.scala
+++ b/core/src/main/scala/org/apache/spark/search/package.scala
@@ -100,11 +100,6 @@ package object search {
   def queryStringBuilder[T](builder: T => String, opts: SearchOptions[_] = defaultOpts): T => Query =
     new QueryStringBuilderWithAnalyzer[T](builder, opts.getReaderOptions.getDefaultFieldName)
 
-  def parseQueryString[T](queryString: String, opts: SearchOptions[_] = defaultOpts): Query =
-  // Query parser is not thread safe
-    new QueryParser(opts.getReaderOptions.getDefaultFieldName, opts.getReaderOptions.analyzer.newInstance())
-      .parse(queryString)
-
   implicit def indexOptions[T](optionsBuilderFunc: Function[IndexationOptions.Builder[T], IndexationOptions.Builder[T]]): JFunction[IndexationOptions.Builder[T], IndexationOptions.Builder[T]] =
     new JFunction[IndexationOptions.Builder[T], IndexationOptions.Builder[T]] {
       override def apply(opts: IndexationOptions.Builder[T]): IndexationOptions.Builder[T] = {

--- a/core/src/main/scala/org/apache/spark/search/rdd/MatchRDD.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/MatchRDD.scala
@@ -26,7 +26,8 @@ import org.apache.spark.util.Utils
 import scala.reflect.ClassTag
 
 /**
- * Result RDD of a [[org.apache.spark.search.rdd.SearchRDDLucene#searchQueryJoin(org.apache.spark.rdd.RDD, scala.Function1, int, double)]]
+ * Result RDD of a
+ * [[org.apache.spark.search.rdd.SearchRDD#searchJoinQuery(org.apache.spark.rdd.RDD, scala.Function1, int, double, scala.reflect.ClassTag)]]
  *
  * @author Pierrick HYMBERT
  */

--- a/core/src/main/scala/org/apache/spark/search/rdd/RDDWithSearch.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/RDDWithSearch.scala
@@ -17,332 +17,69 @@ package org.apache.spark.search.rdd
 
 import org.apache.lucene.search.Query
 import org.apache.spark.rdd.RDD
-import org.apache.spark.search.SearchOptions
-import org.apache.spark.search._
+import org.apache.spark.search.{SearchOptions, _}
 
 import scala.reflect.ClassTag
 
 /**
  * Add search features to [[org.apache.spark.rdd.RDD]]
- * using [[org.apache.spark.search.rdd.SearchRDD]].
+ * using [[org.apache.spark.search.rdd.SearchRDDLucene]].
  *
  * @author Pierrick HYMBERT
  */
-private[rdd] class RDDWithSearch[T: ClassTag](val rdd: RDD[T]) {
+private[rdd] class RDDWithSearch[T: ClassTag](val rdd: RDD[T],
+                                              val opts: SearchOptions[T] = defaultOpts[T]
+                                             ) extends SearchRDD[T] {
 
-  /**
-   * Count how many documents match the given query.
-   *
-   * @param query Matching query
-   * @return Matched doc count
-   */
-  def count(query: String): Long =
-    searchRDD.countQuery(parseQueryString(query))
+  private lazy val searchRDD: SearchRDD[T] = searchRDD(opts)
 
-  /**
-   * Count how many documents match the given query.
-   *
-   * @param query Matching query
-   * @param opts  Search options
-   * @return Matched doc count
-   */
-  def count(query: String, opts: SearchOptions[T]): Long =
-    searchRDD(opts).countQuery(parseQueryString(query))
+  override def count(): Long = searchRDD.count()
 
-  /**
-   * Count how many documents match the given query.
-   *
-   * @param query Matching query
-   * @return Matched doc count
-   */
-  def countQuery(query: () => Query): Long =
-    searchRDD.countQuery(query)
+  override def count(query: Query): Long = searchRDD.count(query)
 
-  /**
-   * Count how many documents match the given query.
-   *
-   * @param query Matching query
-   * @param opts  Search options
-   * @return Matched doc count
-   */
-  def countQuery(query: () => Query, opts: SearchOptions[T]): Long =
-    searchRDD(opts).countQuery(query)
+  override def searchListQuery(query: Query,
+                               topK: Int = Int.MaxValue,
+                               minScore: Double = 0): Array[SearchRecord[T]] =
+    searchRDD.searchListQuery(query, topK, minScore)
 
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query Lucene query syntax
-   * @return matching hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchList(query: String): Array[SearchRecord[T]] =
-    searchRDD.searchQueryList(parseQueryString(query))
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query Lucene query syntax
-   * @param topK  topK to return
-   * @return topK hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchList(query: String,
-                 topK: Int): Array[SearchRecord[T]] =
-    searchRDD.searchQueryList(parseQueryString(query), topK)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query    Lucene query syntax
-   * @param topK     topK to return
-   * @param minScore minimum score of matching documents
-   * @return topK hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchList(query: String,
-                 topK: Int,
-                 minScore: Double): Array[SearchRecord[T]] =
-    searchRDD.searchQueryList(parseQueryString(query), topK, minScore)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query    Lucene query syntax
-   * @param topK     topK to return
-   * @param minScore minimum score of matching documents
-   * @param opts     Search options
-   * @return topK hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchList(query: String,
-                 topK: Int,
-                 minScore: Double,
-                 opts: SearchOptions[T]): Array[SearchRecord[T]] =
-    searchRDD(opts).searchQueryList(parseQueryString(query), topK, minScore)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query Lucene query syntax
-   * @return matching hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchQueryList(query: () => Query): Array[SearchRecord[T]] =
-    searchRDD.searchQueryList(query)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query Lucene query syntax
-   * @param topK  topK to return
-   * @return topK hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchQueryList(query: () => Query,
-                 topK: Int): Array[SearchRecord[T]] =
-    searchRDD.searchQueryList(query, topK)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query    Lucene query syntax
-   * @param topK     topK to return
-   * @param minScore minimum score of matching documents
-   * @return topK hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchQueryList(query: () => Query,
-                 topK: Int,
-                 minScore: Double): Array[SearchRecord[T]] =
-    searchRDD.searchQueryList(query, topK, minScore)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query    Lucene query syntax
-   * @param topK     topK to return
-   * @param minScore minimum score of matching documents
-   * @param opts     Search options
-   * @return topK hits
-   * @note this method should only be used if the topK is expected to be small, as
-   *       all the data is loaded into the driver's memory.
-   */
-  def searchQueryList(query: () => Query,
-                 topK: Int,
-                 minScore: Double,
-                 opts: SearchOptions[T]): Array[SearchRecord[T]] =
-    searchRDD(opts).searchQueryList(query, topK, minScore)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query Lucene query syntax
-   * @return matching hits RDD
-   */
-  def search(query: String): RDD[SearchRecord[T]] =
-    searchRDD.search(query)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query           Lucene query syntax
-   * @param topKByPartition topK to return
-   * @return topK per partition hits RDD
-   */
-  def search(query: String,
-             topKByPartition: Int): RDD[SearchRecord[T]] =
-    searchRDD.search(query, topKByPartition)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query           Lucene query syntax
-   * @param topKByPartition topK to return
-   * @param minScore        minimum score of matching documents
-   * @return topK per partition hits RDD
-   */
-  def search(query: String,
-             topKByPartition: Int,
-             minScore: Double): RDD[SearchRecord[T]] =
-    searchRDD.search(query, topKByPartition, minScore)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query           Lucene query syntax
-   * @param topKByPartition topK to return
-   * @param opts            Search options
-   * @return topK partition hits RDD
-   */
-  def search(query: String,
-             topKByPartition: Int,
-             minScore: Double,
-             opts: SearchOptions[T]): RDD[SearchRecord[T]] =
-    searchRDD(opts).search(query, topKByPartition, minScore)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query Lucene query syntax
-   * @return matching hits RDD
-   */
-  def searchQuery(query: () => Query): RDD[SearchRecord[T]] =
-    searchRDD.searchQuery(query)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query           Lucene query syntax
-   * @param topKByPartition topK to return
-   * @return topK hits per partition RDD
-   */
-  def searchQuery(query: () => Query,
-             topKByPartition: Int): RDD[SearchRecord[T]] =
-    searchRDD.searchQuery(query, topKByPartition)
-
-  /**
-   * Finds the top topK hits for query.
-   *
-   * @param query           Lucene query syntax
-   * @param topKByPartition topK to return
-   * @param minScore        minimum score of matching documents
-   * @return topK hits per partition RDD
-   */
-  def searchQuery(query: () => Query,
-             topKByPartition: Int,
-             minScore: Double): RDD[SearchRecord[T]] =
+  override def searchQuery(query: Query,
+                           topKByPartition: Int = Int.MaxValue,
+                           minScore: Double = 0): RDD[SearchRecord[T]] =
     searchRDD.searchQuery(query, topKByPartition, minScore)
 
+
+  override def searchJoin[S: ClassTag](rdd: RDD[S],
+                                       queryBuilder: S => String,
+                                       topK: Int = Int.MaxValue,
+                                       minScore: Double = 0
+                                      ): RDD[Match[S, T]] =
+    searchRDD.searchJoin(rdd, queryBuilder, topK, minScore)
+
+  override def searchJoinQuery[S: ClassTag](rdd: RDD[S],
+                                            queryBuilder: S => Query,
+                                            topK: Int = Int.MaxValue,
+                                            minScore: Double = 0
+                                           ): RDD[Match[S, T]] =
+    searchRDD.searchJoinQuery(rdd, queryBuilder, topK, minScore)
+
+
+  override def searchDropDuplicates(queryBuilder: T => Query = defaultQueryBuilder(options),
+                                    topK: Int = Int.MaxValue,
+                                    minScore: Double = 0,
+                                    numPartitions: Int = getNumPartitions): RDD[T] =
+    searchRDD.searchDropDuplicates(queryBuilder, topK, minScore, numPartitions)
+
+  override def save(path: String): Unit = searchRDD.save(path)
+
+  override def getNumPartitions: Int = searchRDD.getNumPartitions
+
+  override def options: SearchOptions[T] = searchRDD.options
+
   /**
-   * Finds the top topK hits for query.
+   * Builds a search rdd with that custom search options.
    *
-   * @param query           Lucene query syntax
-   * @param topKByPartition topK to return
-   * @param minScore        minimum score of matching documents
-   * @param opts            Search options
-   * @return topK hits per partition RDD
-   */
-  def searchQuery(query: () => Query,
-             topKByPartition: Int,
-             minScore: Double,
-             opts: SearchOptions[T]): RDD[SearchRecord[T]] =
-    searchRDD(opts).searchQuery(query, topKByPartition, minScore)
-
-  /**
-   * Joins the input RDD against this one and returns matching hits.
-   */
-  def searchJoin[S: ClassTag](rdd: RDD[S], queryBuilder: S => String): RDD[Match[S, T]] =
-    searchRDD.searchJoin(rdd, queryBuilder)
-
-  /**
-   * Joins the input RDD against this one and returns matching hits.
-   */
-  def searchJoin[S: ClassTag](rdd: RDD[S],
-                              queryBuilder: S => String,
-                              topK: Int): RDD[Match[S, T]] =
-    searchRDD.searchJoin(rdd, queryBuilder, topK)
-
-  /**
-   * Joins the input RDD against this one and returns matching hits.
-   */
-  def searchJoin[S: ClassTag](rdd: RDD[S],
-                              queryBuilder: S => String,
-                              topK: Int,
-                              minScore: Double,
-                              opts: SearchOptions[T]): RDD[Match[S, T]] =
-    searchRDD(opts).searchJoin(rdd, queryBuilder, topK, minScore)
-
-  /**
-   * Joins the input RDD against this one and returns matching hits.
-   */
-  def searchQueryJoin[S: ClassTag](rdd: RDD[S], queryBuilder: S => Query): RDD[Match[S, T]] =
-    searchRDD.searchQueryJoin(rdd, queryBuilder)
-
-  /**
-   * Joins the input RDD against this one and returns matching hits.
-   */
-  def searchQueryJoin[S: ClassTag](rdd: RDD[S],
-                              queryBuilder: S => Query,
-                              topK: Int): RDD[Match[S, T]] =
-    searchRDD.searchQueryJoin(rdd, queryBuilder, topK)
-
-  /**
-   * Joins the input RDD against this one and returns matching hits.
-   */
-  def searchQueryJoin[S: ClassTag](rdd: RDD[S],
-                                   queryBuilder: S => Query,
-                                   topK: Int,
-                                   minScore: Double): RDD[Match[S, T]] =
-    searchRDD.searchQueryJoin(rdd, queryBuilder, topK, minScore)
-
-  /**
-   * Joins the input RDD against this one and returns matching hits.
-   */
-  def searchQueryJoin[S: ClassTag](rdd: RDD[S],
-                              queryBuilder: S => Query,
-                              topK: Int,
-                              minScore: Double,
-                              opts: SearchOptions[T]): RDD[Match[S, T]] =
-    searchRDD(opts).searchQueryJoin(rdd, queryBuilder, topK, minScore)
-
-  /**
-   * @return Dependent RDD with search features
-   */
-  def searchRDD: SearchRDD[T] = searchRDD(defaultOpts)
-
-  /**
    * @param opts Search options
    * @return Dependent RDD with configurable search features
    */
-  def searchRDD(opts: SearchOptions[T]): SearchRDD[T] = new SearchRDD[T](rdd, opts)
-
-  sealed trait QueryBuilder[S] extends (S => Query)
-
+  def searchRDD(opts: SearchOptions[T] = defaultOpts): SearchRDD[T] = new SearchRDDLucene[T](rdd, opts)
 }

--- a/core/src/main/scala/org/apache/spark/search/rdd/RDDWithSearch.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/RDDWithSearch.scala
@@ -35,14 +35,14 @@ private[rdd] class RDDWithSearch[T: ClassTag](val rdd: RDD[T],
 
   override def count(): Long = searchRDD.count()
 
-  override def count(query: Query): Long = searchRDD.count(query)
+  override def count(query: StaticQueryProvider): Long = searchRDD.count(query)
 
-  override def searchListQuery(query: Query,
+  override def searchListQuery(query: StaticQueryProvider,
                                topK: Int = Int.MaxValue,
                                minScore: Double = 0): Array[SearchRecord[T]] =
     searchRDD.searchListQuery(query, topK, minScore)
 
-  override def searchQuery(query: Query,
+  override def searchQuery(query: StaticQueryProvider,
                            topKByPartition: Int = Int.MaxValue,
                            minScore: Double = 0): RDD[SearchRecord[T]] =
     searchRDD.searchQuery(query, topKByPartition, minScore)

--- a/core/src/main/scala/org/apache/spark/search/rdd/SearchJavaBaseRDD.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/SearchJavaBaseRDD.scala
@@ -29,16 +29,16 @@ class SearchJavaBaseRDD[T: ClassTag](rdd: JavaRDD[T], opts: SearchOptions[T])
   protected val searchRDD: SearchRDD[T] = rdd.rdd.searchRDD(opts)
 
   override def count(query: String): Long =
-    searchRDD.countQuery(parseQueryString(query))
+    searchRDD.count(parseQueryString(query))
 
   override def searchList(query: String, topK: Int): Array[SearchRecordJava[T]] =
-    searchRDD.searchQueryList(parseQueryString(query), topK).map(searchRecordAsJava)
+    searchRDD.searchListQuery(parseQueryString(query), topK).map(searchRecordAsJava(_))
 
   override def searchList(query: String, topK: Int, minScore: Double): Array[SearchRecordJava[T]] =
-    searchRDD.searchQueryList(parseQueryString(query), topK, minScore).map(searchRecordAsJava)
+    searchRDD.searchListQuery(parseQueryString(query), topK, minScore).map(searchRecordAsJava)
 
   override def search(query: String, topK: Int, minScore: Double): JavaRDD[SearchRecordJava[T]] =
-    searchRDD.search(query, topK).map(searchRecordAsJava).toJavaRDD()
+    searchRDD.search(query, topK).map(searchRecordAsJava(_)).toJavaRDD()
 
   private def matchAsJava[S: ClassTag](s: Match[S, T]): MatchJava[S, T] = {
     new MatchJava[S, T](s.doc, s.hits.map(searchRecordAsJava))

--- a/core/src/main/scala/org/apache/spark/search/rdd/SearchRDD.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/SearchRDD.scala
@@ -15,261 +15,173 @@
  */
 package org.apache.spark.search.rdd
 
-import java.io.{IOException, ObjectOutputStream}
-import java.util.Objects
-
 import org.apache.lucene.search.Query
-import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.search._
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.Utils
 
 import scala.reflect.ClassTag
 
+
 /**
- * A search RDD indexes parent RDD partitions to lucene indexes.
- * It builds for all parent RDD partitions a one-2-one volatile Lucene index
- * available during the lifecycle of the spark session across executors local directories and RAM.
+ * A search RDD Spark Search brings
+ * advanced full text search features to your RDD.
  *
+ * {@link org.apache.spark.search.rdd.SearchRDDLucene}
+ *
+ * @tparam T Doc type to index
  * @author Pierrick HYMBERT
  */
-private[search] class SearchRDD[T: ClassTag](sc: SparkContext,
-                                             var searchIndexRDD: SearchIndexedRDD[T],
-                                             val options: SearchOptions[T],
-                                             val deps: Seq[Dependency[_]])
-  extends RDD[T](sc, Seq(new OneToOneDependency(searchIndexRDD)) ++ deps) {
-
-  if (options.getIndexationOptions.isCacheSearchIndexRDD) {
-    searchIndexRDD.persist(StorageLevel.DISK_ONLY)
-  }
-
+trait SearchRDD[T] {
   /**
    * Return the number of indexed elements in the RDD.
    */
-  override def count: Long = runSearchJob[Long, Long](spr => spr.count(), _.sum)
+  def count(): Long
 
   /**
-   * Count how many documents match the given query.
-   */
-  def count(query: String): Long = countQuery(parseQueryString(query, options))
-
-  /**
-   * Count how many documents match the given query.
-   */
-  def countQuery(query: () => Query): Long = runSearchJob[Long, Long](spr => spr.count(query()), _.sum)
-
-  /**
-   * Finds the top topK hits for this query.
+   * Count how many documents match the given text query.
    *
+   * @param query Matching query
+   * @return Matched doc count
+   */
+  def count(query: String): Long =
+    count(parseQueryString(query, options))
+
+  /**
+   * Count how many documents match the given lucene query.
+   *
+   * @param query Query to match
+   * @return Matched doc count
+   */
+  def count(query: Query): Long
+
+  /**
+   * Searches the top k hits for this query string.
+   *
+   * @param query    Lucene query syntax
+   * @param topK     topK to return
+   * @param minScore minimum score of matching documents
+   * @return topK hits collected to the driver as an array
    * @note this method should only be used if the topK is expected to be small, as
    *       all the data is loaded into the driver's memory.
    */
-  def searchList(query: String, topK: Int = Int.MaxValue, minScore: Double = 0): Array[SearchRecord[T]] =
-    searchQueryList(parseQueryString(query, options), topK, minScore)
+  def searchList(query: String,
+                 topK: Int = Int.MaxValue,
+                 minScore: Double = 0): Array[SearchRecord[T]]
+  = searchListQuery(parseQueryString(query, options), topK, minScore)
 
   /**
-   * Finds the top topK hits for this query.
+   * Searches the top topK hits for this Lucene query.
    *
+   * @param query    Lucene query syntax
+   * @param topK     topK to return
+   * @param minScore minimum score of matching documents
+   * @return topK hits
    * @note this method should only be used if the topK is expected to be small, as
    *       all the data is loaded into the driver's memory.
    */
-  def searchQueryList(query: () => Query, topK: Int = Int.MaxValue, minScore: Double = 0): Array[SearchRecord[T]] =
-    runSearchJob[Array[SearchRecord[T]], Array[SearchRecord[T]]](
-      spr => _partitionReaderSearchList(spr, query, topK, minScore).toArray,
-      reduceSearchRecordsByTopK(topK))
+  def searchListQuery(query: Query,
+                      topK: Int = Int.MaxValue,
+                      minScore: Double = 0): Array[SearchRecord[T]]
 
   /**
-   * Finds the top topK hits per partition for query.
+   * Searches for the top K hits
+   * per partition for this query string
+   * and returns an RDD with all hits sorted by score in descendent order.
+   *
+   * @param query           Lucene query syntax
+   * @param topKByPartition topK to return per partition
+   * @param minScore        minimum score of matching documents
+   * @return topK per partition hits RDD sorted by score in descendent order
    */
-  def search(query: String, topKByPartition: Int = Int.MaxValue, minScore: Double = 0): RDD[SearchRecord[T]] =
+  def search(query: String,
+             topKByPartition: Int = Int.MaxValue,
+             minScore: Double = 0): RDD[SearchRecord[T]] =
     searchQuery(parseQueryString(query, options), topKByPartition, minScore)
 
   /**
-   * Finds the top topK hits per partition for query.
+   * Searches for the top K hits per partition for this lucene query
+   * and returns an RDD with all hits sorted by score in descendent order.
+   *
+   * @param query           Lucene query
+   * @param topKByPartition topK to return per partition
+   * @param minScore        minimum score of matching documents
+   * @return topK per partition hits RDD sorted by score in descendent order
    */
-  def searchQuery(query: () => Query, topKByPartition: Int = Int.MaxValue, minScore: Double = 0): RDD[SearchRecord[T]] = {
-    val indexDirectoryByPartition = searchIndexRDD._indexDirectoryByPartition
-    searchIndexRDD.mapPartitionsWithIndex((index, _) =>
-      tryAndClose(reader(indexDirectoryByPartition, index)) {
-        spr => _partitionReaderSearchList(spr, query, topKByPartition, minScore)
-      }.iterator
-    ).sortBy(_.score, ascending = false)
-  }
+  def searchQuery(query: Query,
+                  topKByPartition: Int = Int.MaxValue,
+                  minScore: Double = 0): RDD[SearchRecord[T]]
 
   /**
-   * Joins the input RDD against this one and returns matching hits.
+   * Searches and joins the input RDD matches against this one
+   * by building a custom lucene query string per doc
+   * and returns matching hits.
+   *
+   * @param rdd          to join with
+   * @param queryBuilder builds the query string to join with the searched document
+   * @param topK         topK to return
+   * @param minScore     minimum score of matching documents
+   * @tparam S Doc type to match with
+   * @return Searched matches documents RDD
    */
   def searchJoin[S: ClassTag](rdd: RDD[S],
                               queryBuilder: S => String,
                               topK: Int = Int.MaxValue,
                               minScore: Double = 0): RDD[Match[S, T]] =
-    searchQueryJoin(rdd, queryStringBuilder(queryBuilder, options), topK, minScore)
+    searchJoinQuery(rdd, queryStringBuilder(queryBuilder, options), topK, minScore)
+
 
   /**
-   * Joins the input RDD against this one and returns matching hits.
+   * Searches and joins the input RDD matches against this one
+   * by building a custom lucene query per doc
+   * and returns matching hits.
+   *
+   * @param rdd          to join with
+   * @param queryBuilder builds the lucene query to join with the searched document
+   * @param topK         topK to return
+   * @param minScore     minimum score of matching documents
+   * @tparam S Doc type to match with
+   * @return Searched matches documents RDD
    */
-  def searchQueryJoin[S: ClassTag](other: RDD[S],
+  def searchJoinQuery[S: ClassTag](rdd: RDD[S],
                                    queryBuilder: S => Query,
                                    topK: Int = Int.MaxValue,
-                                   minScore: Double = 0): RDD[Match[S, T]] = {
-    val topKReducer = (matches: Iterator[SearchRecord[T]]) => matches.toArray
-      .sortBy(_.score)(Ordering.Double.reverse)
-      .take(topK)
-      .iterator
-
-    val otherZipped = other.zipWithIndex.map(_.swap)
-    otherZipped
-      .join(new MatchRDD[S, T](this, otherZipped, queryBuilder, topK, minScore))
-      .reduceByKey((d1, d2) => (d1._1, topKReducer(d1._2 ++ d2._2)))
-      .map {
-        case (_, (doc, matches)) =>
-          new Match[S, T](doc, matches.toArray)
-      }
-  }
+                                   minScore: Double = 0): RDD[Match[S, T]]
 
   /**
-   * alias for dropDuplicates
+   * Alias for
+   * {@link org.apache.spark.search.rdd.SearchRDD#searchDropDuplicates(scala.Function1, int, double, int)}.
    */
-  override def distinct(numPartitions: Int)(implicit ord: Ordering[T]): RDD[T] =
+  def distinct(numPartitions: Int): RDD[T] =
     searchDropDuplicates(numPartitions = numPartitions)
 
   /**
-   * Drop duplicates records by applying lookup for matching hits of the query against this RDD.
+   * Drops duplicated records by applying lookup for matching hits of the query against this RDD.
+   *
+   * @param queryBuilder  builds the lucene query to search for duplicate
+   * @param topK          topK to return
+   * @param minScore      minimum score of matching documents
+   * @param numPartitions num partition of the
    */
   def searchDropDuplicates(queryBuilder: T => Query = defaultQueryBuilder(options),
                            topK: Int = Int.MaxValue,
                            minScore: Double = 0,
-                           numPartitions: Int = getNumPartitions): RDD[T] = {
-    searchQueryJoin[T](parent(1), queryBuilder, topK, minScore) // FIXME add tests
-      .map(m => {
-        val matchHashes = m.hits.filter(_.source.hashCode != m.doc.hashCode).map(_.source.hashCode)
-        val allHashes = (Seq(m.doc.hashCode) ++ matchHashes).sorted
-        (Objects.hash(allHashes), m.doc)
-      })
-      .reduceByKey((m1, _) => m1)
-      .map(_._2)
-      .repartition(numPartitions)
-  }
+                           numPartitions: Int = getNumPartitions): RDD[T]
 
   /**
-   * Save the current indexed RDD in order to be able to reload it later.
+   * Save the current indexed RDD onto hdfs
+   * in order to be able to reload it later on.
    *
-   * @param path Path on the spark file system to save on
+   * @param path Path on the spark file system (hdfs) to save on
    */
-  def save(path: String): Unit = {
-    logInfo(s"Saving index with ${getNumPartitions} partitions to ${path} ...")
-    // Be sure we are indexed
-    count
+  def save(path: String): Unit
 
-    searchIndexRDD.save(path)
-
-    logInfo(s"Index with ${getNumPartitions} partitions saved to ${path}")
-  }
-
-  def this(rdd: RDD[T], options: SearchOptions[T]) {
-    this(rdd.sparkContext, new SearchIndexedRDD(rdd, options), options, Seq(new OneToOneDependency(rdd)))
-  }
-
-  override val partitioner: Option[Partitioner] = searchIndexRDD.partitioner
-
-  override def getPreferredLocations(split: Partition): Seq[String] =
-    firstParent[T].asInstanceOf[SearchIndexedRDD[T]]
-      .getPreferredLocations(split.asInstanceOf[SearchPartition[T]].searchIndexPartition)
-
-  override def repartition(numPartitions: Int)(implicit ord: Ordering[T]): RDD[T]
-  = new SearchRDD[T](firstParent.firstParent.repartition(numPartitions), options)
-
-  def _partitionReaderSearchList(r: SearchPartitionReader[T],
-                                 query: () => Query, topK: Int, minScore: Double): Array[SearchRecord[T]] =
-    r.search(query(), topK, minScore).map(searchRecordJavaToProduct)
-
-  protected[rdd] def reduceSearchRecordsByTopK(topK: Int): Iterator[Array[SearchRecord[T]]] => Array[SearchRecord[T]] =
-    _.reduce(_ ++ _).sortBy(_.score)(Ordering[Double].reverse).take(topK)
-
-  protected[rdd] def runSearchJob[R: ClassTag, A: ClassTag](searchByPartition: SearchPartitionReader[T] => R,
-                                                            reducer: Iterator[R] => A): A =
-    runSearchJobWithContext((_searchByPartition, _) => searchByPartition(_searchByPartition), reducer)
-
-  protected[rdd] def runSearchJobWithContext[R: ClassTag, A: ClassTag](searchByPartitionWithContext: (SearchPartitionReader[T], TaskContext) => R,
-                                                                       reducer: Iterator[R] => A): A = {
-    val indexDirectoryByPartition = searchIndexRDD._indexDirectoryByPartition
-    val ret = sparkContext.runJob(this, (context: TaskContext, partitionZipped: Iterator[T]) => {
-      val index = context.partitionId()
-
-      tryAndClose(reader(indexDirectoryByPartition, index)) {
-        r => searchByPartitionWithContext(r, context)
-      }
-    })
-    reducer(ret.toIterator)
-  }
-
-  def reader(indexDirectoryByPartition: Map[Int, String], index: Int): SearchPartitionReader[T] =
-    reader(index, indexDirectoryByPartition(index))
-
-  def reader(index: Int, indexDirectory: String): SearchPartitionReader[T] =
-    new SearchPartitionReader[T](index, indexDirectory,
-      elementClassTag.runtimeClass.asInstanceOf[Class[T]],
-      options.getReaderOptions)
-
-  override def compute(split: Partition, context: TaskContext): Iterator[T] = {
-    val searchRDDPartition = split.asInstanceOf[SearchPartition[T]]
-
-    // Trigger indexation if not done yet
-    val it = firstParent[Array[Byte]].iterator(searchRDDPartition.searchIndexPartition, context)
-
-    // Unzip if needed
-    ZipUtils.unzipPartition(searchRDDPartition.searchIndexPartition.indexDir, it)
-
-    Iterator()
-  }
-
-  override protected def getPartitions: Array[Partition] = {
-    // One-2-One partition
-    firstParent.partitions.map(p =>
-      new SearchPartition(p.index, searchIndexRDD)).toArray
-  }
-
-  override def persist(newLevel: StorageLevel): SearchRDD.this.type = {
-    if (newLevel != StorageLevel.MEMORY_ONLY && newLevel != StorageLevel.NONE) {
-      throw new SearchException("persisting SearchRDD is not supported, save(String) to restore it later on")
-    }
-    super.persist(newLevel)
-  }
-
-  override def clearDependencies() {
-    super.clearDependencies()
-    if (options.getIndexationOptions.isCacheSearchIndexRDD) {
-      searchIndexRDD.unpersist()
-    }
-    searchIndexRDD = null
-  }
-}
-
-class SearchPartition[T](val idx: Int,
-                         @transient private val searchRDD: SearchIndexedRDD[T]) extends Partition {
-  override def index: Int = idx
-
-  var searchIndexPartition: SearchPartitionIndex[T] = searchRDD.partitions(idx).asInstanceOf[SearchPartitionIndex[T]]
-
-  @throws(classOf[IOException])
-  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
-    // Update the reference to parent split at the time of task serialization
-    searchIndexPartition = searchRDD.partitions(idx).asInstanceOf[SearchPartitionIndex[T]]
-    oos.defaultWriteObject()
-  }
-}
-
-object SearchRDD {
   /**
-   * Reload an indexed RDD from spark FS.
-   *
-   * @param sc      current spark context
-   * @param path    Path where the index were saved
-   * @param options Search option
-   * @tparam T Type of beans or case class this RDD is binded to
-   * @return Restored RDD
+   * @return the number of partitions of this RDD.
    */
-  def load[T: ClassTag](sc: SparkContext, path: String, options: SearchOptions[T] = defaultOpts[T]): SearchRDD[T] =
-    new SearchRDD[T](sc, new SearchIndexReloadedRDD[T](sc, path, options), options, Nil)
+  def getNumPartitions: Int
+
+  /**
+   * @return current search options
+   */
+  def options: SearchOptions[T]
 }

--- a/core/src/main/scala/org/apache/spark/search/rdd/SearchRDD.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/SearchRDD.scala
@@ -149,7 +149,7 @@ trait SearchRDD[T] {
 
   /**
    * Alias for
-   * {@link org.apache.spark.search.rdd.SearchRDD#searchDropDuplicates(scala.Function1, int, double, int)}.
+   * [[org.apache.spark.search.rdd.SearchRDD#searchDropDuplicates(scala.Function1, int, double, int)}]]
    */
   def distinct(numPartitions: Int): RDD[T] =
     searchDropDuplicates(numPartitions = numPartitions)

--- a/core/src/main/scala/org/apache/spark/search/rdd/SearchRDD.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/SearchRDD.scala
@@ -52,7 +52,7 @@ trait SearchRDD[T] {
    * @param query Query to match
    * @return Matched doc count
    */
-  def count(query: Query): Long
+  def count(query: StaticQueryProvider): Long
 
   /**
    * Searches the top k hits for this query string.
@@ -79,7 +79,7 @@ trait SearchRDD[T] {
    * @note this method should only be used if the topK is expected to be small, as
    *       all the data is loaded into the driver's memory.
    */
-  def searchListQuery(query: Query,
+  def searchListQuery(query: StaticQueryProvider,
                       topK: Int = Int.MaxValue,
                       minScore: Double = 0): Array[SearchRecord[T]]
 
@@ -107,7 +107,7 @@ trait SearchRDD[T] {
    * @param minScore        minimum score of matching documents
    * @return topK per partition hits RDD sorted by score in descendent order
    */
-  def searchQuery(query: Query,
+  def searchQuery(query: StaticQueryProvider,
                   topKByPartition: Int = Int.MaxValue,
                   minScore: Double = 0): RDD[SearchRecord[T]]
 

--- a/core/src/main/scala/org/apache/spark/search/rdd/SearchRDDLucene.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/SearchRDDLucene.scala
@@ -1,0 +1,218 @@
+/**
+ * Copyright © 2020 Spark Search (The Spark Search Contributors)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.search.rdd
+
+import java.io.{IOException, ObjectOutputStream}
+import java.util.Objects
+
+import org.apache.lucene.search.Query
+import org.apache.spark._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.search._
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.Utils
+
+import scala.reflect.ClassTag
+
+
+/**
+ * A search RDD indexes parent RDD partitions to lucene indexes.
+ * It builds for all parent RDD partitions a one-2-one volatile Lucene index
+ * available during the lifecycle of the spark session across executors local directories and RAM.
+ *
+ * @author Pierrick HYMBERT
+ */
+private[search] class SearchRDDLucene[T: ClassTag](sc: SparkContext,
+                                                   var searchIndexRDD: SearchIndexedRDD[T],
+                                                   val options: SearchOptions[T],
+                                                   val deps: Seq[Dependency[_]])
+  extends RDD[T](sc, Seq(new OneToOneDependency(searchIndexRDD)) ++ deps)
+    with SearchRDD[T] {
+
+  def this(rdd: RDD[T], options: SearchOptions[T]) {
+    this(rdd.sparkContext,
+      new SearchIndexedRDD(rdd, options),
+      options,
+      Seq(new OneToOneDependency(rdd)))
+  }
+
+  if (options.getIndexationOptions.isCacheSearchIndexRDD) {
+    searchIndexRDD.persist(StorageLevel.DISK_ONLY)
+  }
+
+  override def count(): Long = runSearchJob[Long, Long](spr => spr.count(), _.sum)
+
+  override def count(query: Query): Long =
+    runSearchJob[Long, Long](spr => spr.count(query), _.sum)
+
+  override def searchListQuery(query: Query,
+                               topK: Int = Int.MaxValue,
+                               minScore: Double = 0
+                              ): Array[SearchRecord[T]] =
+    runSearchJob[Array[SearchRecord[T]], Array[SearchRecord[T]]](
+      spr => _partitionReaderSearchList(spr, query, topK, minScore),
+      reduceSearchRecordsByTopK(topK))
+
+  override def searchQuery(query: Query,
+                           topKByPartition: Int = Int.MaxValue,
+                           minScore: Double = 0
+                          ): RDD[SearchRecord[T]] = {
+    val indexDirectoryByPartition = searchIndexRDD._indexDirectoryByPartition
+    searchIndexRDD.mapPartitionsWithIndex(
+      (index, _) =>
+        tryAndClose(reader(indexDirectoryByPartition, index)) {
+          spr => _partitionReaderSearchList(spr, query, topKByPartition, minScore)
+        }.iterator
+    ).sortBy(_.score, ascending = false)
+  }
+
+  override def searchJoinQuery[S: ClassTag](other: RDD[S],
+                                            queryBuilder: S => Query,
+                                            topK: Int = Int.MaxValue,
+                                            minScore: Double = 0
+                                           ): RDD[Match[S, T]] = {
+    val topKReducer = (matches: Iterator[SearchRecord[T]]) => matches.toArray
+      .sortBy(_.score)(Ordering.Double.reverse)
+      .take(topK)
+      .iterator
+
+    val otherZipped = other.zipWithIndex.map(_.swap)
+    otherZipped
+      .join(new MatchRDD[S, T](this, otherZipped, queryBuilder, topK, minScore))
+      .reduceByKey((d1, d2) => (d1._1, topKReducer(d1._2 ++ d2._2)))
+      .map {
+        case (_, (doc, matches)) =>
+          new Match[S, T](doc, matches.toArray)
+      }
+  }
+
+  override def distinct(numPartitions: Int): RDD[T] =
+    searchDropDuplicates(numPartitions = numPartitions)
+
+  override def searchDropDuplicates(queryBuilder: T => Query = defaultQueryBuilder(options),
+                                    topK: Int = Int.MaxValue,
+                                    minScore: Double = 0,
+                                    numPartitions: Int = getNumPartitions
+                                   ): RDD[T] = {
+    searchJoinQuery[T](parent(1), queryBuilder, topK, minScore) // FIXME add tests #24
+      .map(m => {
+        val matchHashes = m.hits.filter(_.source.hashCode != m.doc.hashCode).map(_.source.hashCode)
+        val allHashes = (Seq(m.doc.hashCode) ++ matchHashes).sorted
+        (Objects.hash(allHashes), m.doc)
+      })
+      .reduceByKey((m1, _) => m1)
+      .map(_._2)
+      .repartition(numPartitions)
+  }
+
+  override def save(path: String): Unit = {
+    logInfo(s"Saving index with ${getNumPartitions} partitions to ${path} ...")
+    // Be sure we are indexed
+    count
+
+    searchIndexRDD.save(path)
+
+    logInfo(s"Index with ${getNumPartitions} partitions saved to ${path}")
+  }
+
+  override val partitioner: Option[Partitioner] = searchIndexRDD.partitioner
+
+  override def getPreferredLocations(split: Partition): Seq[String] =
+    firstParent[T].asInstanceOf[SearchIndexedRDD[T]]
+      .getPreferredLocations(split.asInstanceOf[SearchPartition[T]].searchIndexPartition)
+
+  override def repartition(numPartitions: Int)(implicit ord: Ordering[T]): RDD[T]
+  = new SearchRDDLucene[T](firstParent.firstParent.repartition(numPartitions), options)
+
+  def _partitionReaderSearchList(r: SearchPartitionReader[T],
+                                 query: Query, topK: Int, minScore: Double): Array[SearchRecord[T]] =
+    r.search(query, topK, minScore).map(searchRecordJavaToProduct)
+
+  protected[rdd] def reduceSearchRecordsByTopK(topK: Int): Iterator[Array[SearchRecord[T]]] => Array[SearchRecord[T]] =
+    _.reduce(_ ++ _).sortBy(_.score)(Ordering[Double].reverse).take(topK)
+
+  protected[rdd] def runSearchJob[R: ClassTag, A: ClassTag](searchByPartition: SearchPartitionReader[T] => R,
+                                                            reducer: Iterator[R] => A): A =
+    runSearchJobWithContext((_searchByPartition, _) => searchByPartition(_searchByPartition), reducer)
+
+  protected[rdd] def runSearchJobWithContext[R: ClassTag, A: ClassTag](searchByPartitionWithContext: (SearchPartitionReader[T], TaskContext) => R,
+                                                                       reducer: Iterator[R] => A): A = {
+    val indexDirectoryByPartition = searchIndexRDD._indexDirectoryByPartition
+    val ret = sparkContext.runJob(this, (context: TaskContext, partitionZipped: Iterator[T]) => {
+      val index = context.partitionId()
+
+      tryAndClose(reader(indexDirectoryByPartition, index)) {
+        r => searchByPartitionWithContext(r, context)
+      }
+    })
+    reducer(ret.toIterator)
+  }
+
+  def reader(indexDirectoryByPartition: Map[Int, String], index: Int): SearchPartitionReader[T] =
+    reader(index, indexDirectoryByPartition(index))
+
+  def reader(index: Int, indexDirectory: String): SearchPartitionReader[T] =
+    new SearchPartitionReader[T](index, indexDirectory,
+      elementClassTag.runtimeClass.asInstanceOf[Class[T]],
+      options.getReaderOptions)
+
+  override def compute(split: Partition, context: TaskContext): Iterator[T] = {
+    val searchRDDPartition = split.asInstanceOf[SearchPartition[T]]
+
+    // Trigger indexation if not done yet
+    val it = firstParent[Array[Byte]].iterator(searchRDDPartition.searchIndexPartition, context)
+
+    // Unzip if needed
+    ZipUtils.unzipPartition(searchRDDPartition.searchIndexPartition.indexDir, it)
+
+    Iterator()
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    // One-2-One partition
+    firstParent.partitions.map(p =>
+      new SearchPartition(p.index, searchIndexRDD)).toArray
+  }
+
+  override def persist(newLevel: StorageLevel): SearchRDDLucene.this.type = {
+    if (newLevel != StorageLevel.MEMORY_ONLY && newLevel != StorageLevel.NONE) {
+      throw new SearchException("persisting SearchRDD is not supported, save(String) to restore it later on")
+    }
+    super.persist(newLevel)
+  }
+
+  override def clearDependencies() {
+    super.clearDependencies()
+    if (options.getIndexationOptions.isCacheSearchIndexRDD) {
+      searchIndexRDD.unpersist()
+    }
+    searchIndexRDD = null
+  }
+}
+
+class SearchPartition[T](val idx: Int,
+                         @transient private val searchRDD: SearchIndexedRDD[T]) extends Partition {
+  override def index: Int = idx
+
+  var searchIndexPartition: SearchPartitionIndex[T] = searchRDD.partitions(idx).asInstanceOf[SearchPartitionIndex[T]]
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    // Update the reference to parent split at the time of task serialization
+    searchIndexPartition = searchRDD.partitions(idx).asInstanceOf[SearchPartitionIndex[T]]
+    oos.defaultWriteObject()
+  }
+}

--- a/core/src/main/scala/org/apache/spark/search/rdd/package.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/package.scala
@@ -15,6 +15,7 @@
  */
 package org.apache.spark.search
 
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 import scala.language.implicitConversions
@@ -27,6 +28,21 @@ import scala.util.{Failure, Success, Try}
 package object rdd {
 
   implicit def rddWithSearch[T: ClassTag](rdd: RDD[T]): RDDWithSearch[T] = new RDDWithSearch[T](rdd)
+
+  /**
+   * Reload an indexed RDD from spark FS.
+   *
+   * @param sc      current spark context
+   * @param path    Path where the index were saved
+   * @param options Search option
+   * @tparam T Type of beans or case class this RDD is binded to
+   * @return Restored RDD
+   */
+  def loadSearchRDD[T: ClassTag](sc: SparkContext,
+                                 path: String,
+                                 options: SearchOptions[T] = defaultOpts[T]
+                                ): SearchRDD[T] =
+    new SearchRDDLucene[T](sc, new SearchIndexReloadedRDD[T](sc, path, options), options, Nil)
 
   private[rdd] def searchRecordJavaToProduct[T](sr: SearchRecordJava[T]) = {
     SearchRecord(sr.id, sr.partitionIndex, sr.score, sr.shardIndex, sr.source)

--- a/core/src/test/scala/org/apache/spark/search/rdd/SearchIndexRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/search/rdd/SearchIndexRDDSuite.scala
@@ -18,14 +18,17 @@ package org.apache.spark.search.rdd
 import java.io.File
 
 import org.apache.commons.io.FileUtils
-import org.apache.spark.search.rdd.TestData.persons
+import org.apache.spark.search.rdd.TestData._
 import org.scalatest.flatspec.AnyFlatSpec
 import ZipUtils._
 
 class SearchIndexRDDSuite extends AnyFlatSpec with LocalSparkContext {
 
   it should "creates zip index and stream to the next rdd" in {
-    val searchIndexedRDD = sc.parallelize(persons).searchRDD.searchIndexRDD
+    val searchIndexedRDD = sc.parallelize(persons)
+      .searchRDD()
+      .asInstanceOf[SearchRDDLucene[Person]]
+      .searchIndexRDD
     searchIndexedRDD.count()
     val indexDirectoryByPartition = searchIndexedRDD._indexDirectoryByPartition
     indexDirectoryByPartition.foreach(t => {

--- a/core/src/test/scala/org/apache/spark/search/rdd/SearchRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/search/rdd/SearchRDDSuite.scala
@@ -22,6 +22,7 @@ import org.apache.lucene.analysis.en.EnglishAnalyzer
 import org.apache.lucene.search.BooleanClause.Occur
 import org.apache.lucene.util.QueryBuilder
 import org.apache.spark.api.java.StorageLevels
+import org.apache.spark.rdd.RDD
 import org.apache.spark.search.rdd.TestData._
 import org.apache.spark.search.{SearchException, _}
 import org.scalatest.funsuite.AnyFunSuite
@@ -47,7 +48,10 @@ class SearchRDDSuite extends AnyFunSuite with LocalSparkContext {
 
   test("search RDD hits matching query") {
     assertResult(Array(new SearchRecord[Person](0, 1, 0.3150668740272522f, 0,
-      Person("Bob", "Marley", 37))))(sc.parallelize(persons).search("firstName:bob", 10).take(10))
+      Person("Bob", "Marley", 37))))(
+      sc.parallelize(persons)
+        .search("firstName:bob", 10).take(10)
+    )
   }
 
   test("search RDD query must use default field") {
@@ -68,7 +72,7 @@ class SearchRDDSuite extends AnyFunSuite with LocalSparkContext {
       Person("Agnes", "Bartol", 0),
       Person("Agnec", "Barttol", 0))
 
-    val searchRDD = sc.parallelize(persons2).repartition(2).searchRDD
+    val searchRDD = sc.parallelize(persons2).repartition(2).searchRDD()
     val matchingRDD = sc.parallelize(persons)
 
     val matches = searchRDD.searchJoin(matchingRDD, (p: Person) => s"firstName:${p.firstName}~0.5 AND lastName:${p.lastName}~0.5", 2).collect
@@ -77,7 +81,8 @@ class SearchRDDSuite extends AnyFunSuite with LocalSparkContext {
   }
 
   test("Persisting RDD to local dirs is forbidden") {
-    val searchRDD = sc.parallelize(Seq(Person("Georges", "Brassens", 99))).searchRDD
+    val searchRDD = sc.parallelize(Seq(Person("Georges", "Brassens", 99)))
+      .searchRDD().asInstanceOf[RDD[Person]]
     assertThrows[SearchException] {
       searchRDD.persist(StorageLevels.MEMORY_AND_DISK)
     }
@@ -94,7 +99,7 @@ class SearchRDDSuite extends AnyFunSuite with LocalSparkContext {
 
   test("self search join with self query value should returns all document with self match") {
     val rdd = sc.parallelize(persons)
-    val searchRDD = rdd.searchQueryJoin(rdd,
+    val searchRDD = rdd.searchJoinQuery(rdd,
       queryBuilder((c: Person, lqb: QueryBuilder) => lqb.createBooleanQuery("firstName", c.firstName, Occur.MUST)),
       topK = 1,
       minScore = 0)
@@ -105,24 +110,26 @@ class SearchRDDSuite extends AnyFunSuite with LocalSparkContext {
 
   test("search join should work") {
     val opts = SearchOptions.builder[Person]().analyzer(classOf[TestPersonAnalyzer]).build()
-    val searchRDD = sc.parallelize(persons2).repartition(1)
-      .searchQueryJoin(sc.parallelize(persons),
+    val searchRDD = sc.parallelize(personsDuplicated).repartition(1)
+      .searchRDD(opts)
+      .searchJoinQuery(sc.parallelize(persons),
         queryBuilder((c: Person, lqb: QueryBuilder) => lqb.createBooleanQuery("firstName", c.firstName), opts),
         2,
-        0,
-        opts)
+        0)
       .filter(_.hits.length == 2)
     assertResult(3)(searchRDD.count)
   }
 
   test("Distinct with no minimum score test RDD") {
-    val searchRDD = sc.parallelize(persons2).repartition(1).searchRDD
-    val deduplicated = searchRDD.distinct().collect
+    val searchRDD = sc.parallelize(personsDuplicated)
+      .repartition(1)
+      .searchRDD()
+    val deduplicated = searchRDD.distinct(1).collect
     assertResult(1)(deduplicated.length)
   }
 
   test("Drop duplicate with min score test RDD") {
-    val searchRDD = sc.parallelize(persons2).repartition(1)
+    val searchRDD = sc.parallelize(personsDuplicated).repartition(1)
       .searchRDD(opts = SearchOptions.builder().analyzer(classOf[TestPersonAnalyzer]).build())
 
     val deduplicated = searchRDD.searchDropDuplicates(minScore = 8).collect
@@ -132,12 +139,12 @@ class SearchRDDSuite extends AnyFunSuite with LocalSparkContext {
   test("Save and restore index from/to hdfs") {
     FileUtils.deleteDirectory(new File("target/test-save"))
 
-    val searchRDD = sc.parallelize(persons).searchRDD
+    val searchRDD = sc.parallelize(persons).searchRDD()
     assertResult(3)(searchRDD.count())
 
     searchRDD.save("target/test-save")
 
-    val restoredSearchRDD = SearchRDD.load[Person](sc, "target/test-save")
-    assertResult(3)(restoredSearchRDD.count)
+    val restoredSearchRDD = loadSearchRDD[Person](sc, "target/test-save")
+    assertResult(3)(restoredSearchRDD.count())
   }
 }

--- a/core/src/test/scala/org/apache/spark/search/rdd/TestData.scala
+++ b/core/src/test/scala/org/apache/spark/search/rdd/TestData.scala
@@ -28,7 +28,7 @@ object TestData {
     Person("Bob", "Marley", 37),
     Person("Agnès", "Bartoll", -1))
 
-  def persons2 = Seq(
+  def personsDuplicated = Seq(
     Person("George", "Michal", 0),
     Person("Georgee", "Michall", 0),
     Person("Bobb", "Marley", 0),

--- a/examples/src/main/java/all/examples/org/apache/spark/search/rdd/SearchRDDJavaExamples.java
+++ b/examples/src/main/java/all/examples/org/apache/spark/search/rdd/SearchRDDJavaExamples.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.search.rdd;
+package all.examples.org.apache.spark.search.rdd;
 
 import org.apache.lucene.analysis.shingle.ShingleAnalyzerWrapper;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.search.SearchOptions;
 import org.apache.spark.search.SearchRecordJava;
+import org.apache.spark.search.rdd.SearchRDDJava;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
 

--- a/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/ExampleData.scala
+++ b/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/ExampleData.scala
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright © 2020 Spark Search (The Spark Search Contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package all.examples.org.apache.spark.search.rdd
 
 import java.io.File

--- a/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/ExampleData.scala
+++ b/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/ExampleData.scala
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2020 Spark Search (The Spark Search Contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.search.rdd
+
+package all.examples.org.apache.spark.search.rdd
 
 import java.io.File
 import java.net.URL

--- a/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/SearchRDDExamples.scala
+++ b/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/SearchRDDExamples.scala
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © 2020 Spark Search (The Spark Search Contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.search.rdd
+package all.examples.org.apache.spark.search.rdd
 
 import org.apache.lucene.analysis.en.EnglishAnalyzer
-import org.apache.spark.search.rdd.ExampleData._
-import org.apache.spark.search.{ReaderOptions, SearchOptions}
+import org.apache.spark.search._
+import org.apache.spark.search.rdd._
 import org.apache.spark.sql.SparkSession
+
+import ExampleData._
 
 /**
  * Spark Search RDD examples.
@@ -72,8 +74,8 @@ object SearchRDDExamples {
 
     // Save & restore example
     println(s"Restoring from previous indexation:")
-    softwareReviewsRDD.searchRDD.save("/tmp/save-path")
-    val restoredSearchRDD = SearchRDD.load[Review](sc, "/tmp/save-path")
+    softwareReviewsRDD.searchRDD().save("/tmp/save-path")
+    val restoredSearchRDD = loadSearchRDD[Review](sc, "/tmp/save-path")
     val happyReview2 = restoredSearchRDD.count("reviewText:happy OR reviewText:best or reviewText:good")
     println(s"${happyReview2} positive reviews after restoration ^^")
 

--- a/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/SearchRDDExamples.scala
+++ b/examples/src/main/scala/all/examples/org/apache/spark/search/rdd/SearchRDDExamples.scala
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright © 2020 Spark Search (The Spark Search Contributors)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -22,7 +22,7 @@ ENV HADOOP_CONF_DIR /opt/hadoop/etc/hadoop
 ENV SPARK_HOME /opt/spark
 ENV PATH="${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin:${SPARK_HOME}/bin:${SPARK_HOME}/sbin:${PATH}"
 ENV HADOOP_VERSION 2.7.0
-ENV SPARK_VERSION 2.4.5
+ENV SPARK_VERSION 2.4.8
 
 RUN apt-get -qq update && \
     apt-get -y -qq upgrade && \

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   spark-master:
-    image: bde2020/spark-master:2.4.8-hadoop2.7
+    image: bde2020/spark-master:2.4.5-hadoop2.7
     container_name: spark-master
     ports:
       - 8080:8080
@@ -11,7 +11,7 @@ services:
     volumes:
       - /tmp:/tmp:rw
   spark-worker-1:
-    image: bde2020/spark-worker:2.4.8-hadoop2.7
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
     depends_on:
       - spark-master
     environment:
@@ -23,7 +23,7 @@ services:
     volumes:
     - /tmp:/tmp:rw
   spark-worker-2:
-    image: bde2020/spark-worker:2.4.8-hadoop2.7
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
     depends_on:
       - spark-master
     environment:
@@ -35,7 +35,7 @@ services:
     volumes:
       - /tmp:/tmp:rw
   spark-worker-3:
-    image: bde2020/spark-worker:2.4.8-hadoop2.7
+    image: bde2020/spark-worker:2.4.5-hadoop2.7
     depends_on:
       - spark-master
     environment:

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   spark-master:
-    image: bde2020/spark-master:2.4.5-hadoop2.7
+    image: bde2020/spark-master:2.4.8-hadoop2.7
     container_name: spark-master
     ports:
       - 8080:8080
@@ -11,7 +11,7 @@ services:
     volumes:
       - /tmp:/tmp:rw
   spark-worker-1:
-    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    image: bde2020/spark-worker:2.4.8-hadoop2.7
     depends_on:
       - spark-master
     environment:
@@ -23,7 +23,7 @@ services:
     volumes:
     - /tmp:/tmp:rw
   spark-worker-2:
-    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    image: bde2020/spark-worker:2.4.8-hadoop2.7
     depends_on:
       - spark-master
     environment:
@@ -35,7 +35,7 @@ services:
     volumes:
       - /tmp:/tmp:rw
   spark-worker-3:
-    image: bde2020/spark-worker:2.4.5-hadoop2.7
+    image: bde2020/spark-worker:2.4.8-hadoop2.7
     depends_on:
       - spark-master
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <lucene.version>8.5.2</lucene.version>
-        <spark.version>2.4.5</spark.version>
+        <spark.version>2.4.8</spark.version>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     </properties>
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -111,7 +111,7 @@ try:
             'pysparksearch.jars': ['*.jar']
         },
         license='http://www.apache.org/licenses/LICENSE-2.0',
-        install_requires=['pyspark==2.4.5'],
+        install_requires=['pyspark==2.4.8'],
         setup_requires=['pypandoc'],
         classifiers=[
             'Development Status :: 0.2.0 - Development/UnStable',

--- a/sql/src/main/scala/org/apache/spark/search/sql/SearchRule.scala
+++ b/sql/src/main/scala/org/apache/spark/search/sql/SearchRule.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sql/src/main/scala/org/apache/spark/search/sql/logical.scala
+++ b/sql/src/main/scala/org/apache/spark/search/sql/logical.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sql/src/test/scala/org/apache/spark/search/sql/SearchDatasetSuite.scala
+++ b/sql/src/test/scala/org/apache/spark/search/sql/SearchDatasetSuite.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
fixes #22 - Make SearchRDD a public trait
- Enhance and correct documentation
- Remove unnecessary overload methods
- Move example to dedicated package to test public trait