### PR TITLE
Document release and deploy process to OSSRH.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -243,6 +243,30 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
                             <execution>
@@ -250,6 +274,20 @@
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>nexus</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                    <goal>deploy-staged</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/doc/DEPLOY.md
+++ b/doc/DEPLOY.md
@@ -1,0 +1,52 @@
+## Deploy Spark Search to The Central Repository (OSSRH)
+1. Read the publish [guide](https://central.sonatype.org/publish/)
+2. The original publish ticket is [OSSRH-58231](https://issues.sonatype.org/browse/OSSRH-58231)
+3. Login & browse to oss Nexus [Releases](https://oss.sonatype.org/#view-repositories;releases~browsestorage~io/github/phymbert) repository
+4. Configure your [GPG keys] (https://central.sonatype.org/publish/requirements/gpg/)
+5. Configure your maven settings server credentials for `sonatype` server id, example:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>sonatype</id>
+      <username>XXX</username>
+      <password>XXXXX</password>
+    </server>
+  </servers>
+</settings>
+```
+
+###  Test the release
+```
+mvn clean verify
+```
+> Ideally github actions might passed, examples must run successfully
+
+### Prepare release
+```
+mvn release:clean release:prepare
+```
+
+### Release and deploy
+```xml
+mvn release:perform
+```
+
+### Deploy an other scala version
+```xml
+mvn clean deploy -Pdeploy,scala-2.12 -pl core,sql
+```
+
+### Repositories
+Artefacts will be available in [OSSRH Releases](https://oss.sonatype.org/content/groups/public/io/github/phymbert/)
+and few hours after in [maven central repo1](https://repo1.maven.org/maven2/io/github/phymbert/) and [maven search](https://search.maven.org/search?q=g:io.github.phymbert). 
+
+### Deploy snapshots
+```xml
+mvn clean deploy -Pdeploy,scala-2.11
+```

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>deploy</releaseProfiles>
+                    <goals>deploy</goals>
                 </configuration>
             </plugin>
             <plugin>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -135,23 +135,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>sonatype</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
@@ -242,6 +225,30 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
                             <execution>
@@ -249,6 +256,20 @@
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>nexus</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                    <goal>deploy-staged</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
 Add by default javadoc and sources in deploy process.

Tested with snapshot only as need to find a solution to exclude 2.12 deployment parent

Closes #42 