### PR TITLE
#Fix #80: Always cache indexed RDD to force read rdd to be on same executor than parent, fix preferred location

### DIFF
--- a/core/src/main/java/org/apache/spark/search/IndexationOptions.java
+++ b/core/src/main/java/org/apache/spark/search/IndexationOptions.java
@@ -79,12 +79,11 @@ public final class IndexationOptions<T> implements Serializable {
                     .orElse(System.getProperty("java.io.tmpdir"))), "spark-search").getAbsolutePath();
 
     /**
-     * Is search index rdd cached, default to true in yarn cluster manager.
+     * Is search index rdd cached, default to true.
      * Caching partitions avoid reindexing parent rdd partition if the search computation occurs on
      * different node than the indexation one.
      */
-    private boolean cacheSearchIndexRDD = Optional.ofNullable(System.getProperty("spark.master"))
-            .filter("yarn"::equals).isPresent();
+    private boolean cacheSearchIndexRDD = true;
 
     /**
      * Log indexation progress every 100K docs.

--- a/core/src/main/scala/org/apache/spark/search/rdd/package.scala
+++ b/core/src/main/scala/org/apache/spark/search/rdd/package.scala
@@ -69,7 +69,7 @@ package object rdd {
       case b: ExecutorAllocationClient =>
         // Try to balance partitions across executors
         val allIds = sc.getExecutorIds()
-        val ids = allIds.sliding(numPartition).toList
+        val ids = allIds.grouped(numPartition).toList
         ids(index % ids.length).toArray
       case _ => parentPreferredLocation.toArray
     }


### PR DESCRIPTION
Closes #80 